### PR TITLE
pr.yaml: ubuntu v20.04 -> latest

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -186,7 +186,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         r-version: ['release']
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
hello! when doing some tool development (using this repo as a template), we got this error:
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```
this PR bumps the version to `latest` to match the other ubuntu version declarations in the various action workflow descriptions