### PR TITLE
Enable markdown report in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,6 +200,7 @@ jobs:
       with:
         mode: combine
         html-report: true
+        markdown-report: true
     - uses: actions/upload-artifact@v4
       with:
         name: 'All tool test results'


### PR DESCRIPTION
Adds the 'markdown-report: true' option to the coverage job in the CI workflow to generate a markdown report alongside the existing HTML report.